### PR TITLE
Fix compilation on nightly

### DIFF
--- a/src/system_core/panic.rs
+++ b/src/system_core/panic.rs
@@ -1,4 +1,4 @@
-use core::panic::PanicInfo;
+use std::panic::PanicInfo;
 use crate::global::LOGGER;
 
 pub fn panic_handler(info: &PanicInfo) {


### PR DESCRIPTION
Relevant rustc issue: https://github.com/rust-lang/rust/issues/126766

Without this change, compiling on nightly results in:
```rust
error[E0308]: mismatched types
  --> src/main.rs:37:23
   |
37 |         panic_handler(info);
   |         ------------- ^^^^ expected `&PanicInfo<'_>`, found `&PanicHookInfo<'_>`
   |         |
   |         arguments to this function are incorrect
   |
   = note: expected reference `&PanicInfo<'_>`
              found reference `&PanicHookInfo<'_>`
note: function defined here
  --> src/system_core/panic.rs:4:8
   |
4  | pub fn panic_handler(info: &PanicInfo) {
   |        ^^^^^^^^^^^^^ ----------------

For more information about this error, try `rustc --explain E0308`.
warning: `strawberry-chat` (bin "strawberry-chat") generated 1 warning
error: could not compile `strawberry-chat` (bin "strawberry-chat") due to 1 previous error; 1 warning emitted
```

This was also the only place where `use core::...;` was used